### PR TITLE
Fix the way we check if the secret is valid

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,5 @@
 {
     "github_access_token" : "XXXXXXXXXX",
+    "github_ips_only" : true,
     "enforce_secret": "SOMELONGSECRETSTRINGTHATYOUPASTEINTOGITHUBORGITEAWEBINTERFACE"
 }

--- a/uncle_archie.py
+++ b/uncle_archie.py
@@ -2,6 +2,9 @@ import os
 import logging
 import subprocess
 from tempfile import mkstemp
+
+from ipaddress import ip_address, ip_network
+
 from os import access, remove, fdopen
 import requests
 import json
@@ -35,12 +38,15 @@ def index():
     print("Uncle Archie got a visitor!")
     path = os.path.dirname(os.path.abspath(__file__))
 
-    # Only POST is implemented
-    if request.method != 'POST':
-        return('<h2>hello world</h2>')
-        #logging.error('ERROR: Only POST method is implemented')
-        #abort(501)
 
+    # -----
+    # Implement a nice hello world landing page
+    if request.method != 'POST':
+        # We really need to make a Jinja template instead.
+        return('<h2>Hello World! This is Uncle Archie, your local home-brewed CI server.</h2>')
+
+
+    # -----
     # Load config
     try:
         pth = os.path.join(path, 'config.json')
@@ -50,6 +56,21 @@ def index():
         logging.error("ERROR: No config file found at %s"%(pth))
         abort(501)
 
+
+    # -----
+    # get source IP (from request)
+    # get Github IP (from API)
+    # verify the requester
+    whitelist = requests.get('https://api.github.com/meta').json()['hooks']
+    for valid_ip in whitelist:
+        if src_ip in ip_network(valid_ip):
+            break
+        else:
+            logging.error('IP {} not allowed'.format(src_ip))
+            abort(403)
+
+
+    # -----
     # Implement ping/pong
     event = request.headers.get('X-GitHub-Event', 'ping')
     if event == 'ping':

--- a/uncle_archie.py
+++ b/uncle_archie.py
@@ -58,16 +58,15 @@ def index():
 
 
     # -----
-    # get source IP (from request)
-    # get Github IP (from API)
-    # verify the requester
-    whitelist = requests.get('https://api.github.com/meta').json()['hooks']
-    for valid_ip in whitelist:
-        if src_ip in ip_network(valid_ip):
-            break
-        else:
-            logging.error('IP {} not allowed'.format(src_ip))
-            abort(403)
+    # Verify webhooks are from Github
+    if 'github_ips_only' in config and config['github_ips_only'] is True:
+        whitelist = requests.get('https://api.github.com/meta').json()['hooks']
+        for valid_ip in whitelist:
+            if src_ip in ip_network(valid_ip):
+                break
+            else:
+                logging.error('IP {} not allowed'.format(src_ip))
+                abort(403)
 
 
     # -----


### PR DESCRIPTION
This was being implemented incorrectly - the secret is not in the *webhook payload* it is in the *HTTP header*, because of course it's more complicated than putting a secret string into a JSON object.